### PR TITLE
Ensure find_by_id returns nil if no id is informed

### DIFF
--- a/lib/proxima/model.rb
+++ b/lib/proxima/model.rb
@@ -86,6 +86,7 @@ module Proxima
     end
 
     def self.find_by_id(id, params = {}, opts = {})
+      return nil if id.blank?
       params[:id] = id
       @response   = self.api.get self.find_by_id_path.call(params), opts
 

--- a/lib/proxima/model.rb
+++ b/lib/proxima/model.rb
@@ -86,7 +86,7 @@ module Proxima
     end
 
     def self.find_by_id(id, params = {}, opts = {})
-      return nil if id.blank?
+      raise "id cannot be blank" if id.blank?
       params[:id] = id
       @response   = self.api.get self.find_by_id_path.call(params), opts
 

--- a/spec/proxima_model_spec.rb
+++ b/spec/proxima_model_spec.rb
@@ -179,13 +179,13 @@ describe Proxima::Model do
     it 'returns nil when an id is not informed' do
       expect_any_instance_of(Proxima::Api).not_to receive(:get)
 
-      expect(
+      expect {
         User.find_by_id(nil, { account_id: 1 }, { headers: { 'X-TEST': '1' } })
-      ).to be_nil
+      }.to raise_error(RuntimeError, 'id cannot be blank')
 
-      expect(
+      expect {
         User.find_by_id('', { account_id: 1 }, { headers: { 'X-TEST': '1' } })
-      ).to be_nil
+      }.to raise_error(RuntimeError, 'id cannot be blank')
     end
   end
 

--- a/spec/proxima_model_spec.rb
+++ b/spec/proxima_model_spec.rb
@@ -163,11 +163,7 @@ describe Proxima::Model do
   describe '.find_by_id' do
 
     it 'sends a query as a get request to the api and returns the first result' do
-      pending
-      mock_response = RestClient::Response.new '{ "name": "Robert", "account": 1 }'
-      mock_response.instance_variable_set :@code, 200
-      mock_response.instance_variable_set :@headers, { x_total_count: 5 }
-
+      mock_response = double('response', body: '{ "name": "Robert", "account": 1 }', code: 200)
       expect_any_instance_of(Proxima::Api).to(
         receive(:get)
           .with("/account/1/user/1", { headers: { :'X-TEST' => '1' } })
@@ -178,6 +174,18 @@ describe Proxima::Model do
       expect(user).to be_a(User)
       expect(user.name).to eql('Robert')
       expect(user.account_id).to equal(1)
+    end
+
+    it 'returns nil when an id is not informed' do
+      expect_any_instance_of(Proxima::Api).not_to receive(:get)
+
+      expect(
+        User.find_by_id(nil, { account_id: 1 }, { headers: { 'X-TEST': '1' } })
+      ).to be_nil
+
+      expect(
+        User.find_by_id('', { account_id: 1 }, { headers: { 'X-TEST': '1' } })
+      ).to be_nil
     end
   end
 


### PR DESCRIPTION
It was using the endpoint for *find* in case ID was nil or empty and returning a collection of models.