### PR TITLE
switch from http/net to http.rb

### DIFF
--- a/lib/proxima.rb
+++ b/lib/proxima.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'http'
 require 'active_model'
 require 'proxima/version'
 require 'proxima/types'

--- a/lib/proxima/request.rb
+++ b/lib/proxima/request.rb
@@ -19,22 +19,21 @@ module Proxima
         opts[:json].to_json
       elsif opts[:body]
         opts[:body]
-      else
-        ''
       end
 
       headers.merge! @api.headers
 
-      @headers          = headers.map{ |name, val| [to_header(name), val.to_s] }.to_h
-      query_str         = opts[:query] ? "?#{opts[:query].to_query}" : ''
-      @uri              = URI.join @api.base_uri, path, query_str
-      @http             = Net::HTTP.new @uri.host, @uri.port
-      @http.use_ssl     = @uri.scheme == "https"
-      @http.verify_mode = OpenSSL::SSL::VERIFY_PEER if @uri.scheme == "https"
+      @headers  = headers.map{ |name, val| [to_header(name), val.to_s] }.to_h
+      query_str = opts[:query] ? "?#{opts[:query].to_query}" : ''
+      @uri      = URI.join(@api.base_uri, path, query_str)
     end
 
     def response
-      raw_response = @http.send_request @method, @uri, @body, @headers
+      raw_response = HTTP
+        .use(:auto_deflate)
+        .headers(@headers)
+        .request @method, @uri, body: @body
+
       Response.new self, raw_response
     end
 

--- a/lib/proxima/response.rb
+++ b/lib/proxima/response.rb
@@ -11,31 +11,23 @@ module Proxima
     end
 
     def json
-      begin
-        JSON.parse @raw_response.body if @raw_response.body
-      rescue => e
-        raise "Failed to parse response body as JSON string: #{e.message}"
-      end
+      @raw_response.parse 'application/json'
     end
 
     def body
-      @raw_response.body
+      @raw_response.body.to_s
     end
 
     def code
-      @raw_response.code.to_i
+      @raw_response.code
     end
 
     def message
-      @raw_response.message
-    end
-
-    def http_version
-      @raw_response.http_version
+      @raw_response.reason
     end
 
     def headers
-      @headers ||= @raw_response.each.to_h.map { |name, val| [from_header(name), val] }.to_h
+      @headers ||= @raw_response.headers.map{ |name, value| [from_header(name), value] }.to_h
     end
 
     private

--- a/proxima.gemspec
+++ b/proxima.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5"
 
+  spec.add_dependency "http", "~> 2.2"
   spec.add_dependency "activemodel", '~> 4.0', '>= 4.0.0'
 end

--- a/spec/proxima_model_spec.rb
+++ b/spec/proxima_model_spec.rb
@@ -51,11 +51,11 @@ describe Proxima::Model do
   describe '.create' do
 
     it 'creates an instance from a record and saves it then returns the model' do
-      pending
-      mock_response = RestClient::Response.new(
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 201
+      expect(mock_response).to receive(:body).and_return(
         '{ "_id": "1", "name": "Robert", "account": 1 }'
       )
-      mock_response.instance_variable_set :@code, 201
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:post)
@@ -73,13 +73,12 @@ describe Proxima::Model do
   describe '.find' do
 
     it 'sends a query as a get request to the api and returns the results' do
-      pending
-      mock_response = RestClient::Response.new(
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 200
+      expect(mock_response).to receive(:body).and_return(
         '[{ "name": "Robert", "account": 1 }, ' +
         '{ "name": "Brandyn", "account": 1 }]'
       )
-      mock_response.instance_variable_set :@code, 200
-      mock_response.instance_variable_set :@headers, { x_total_count: 5 }
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:get)
@@ -91,6 +90,7 @@ describe Proxima::Model do
       )
       users = User.find(
         { account_id: 1 },
+        {},
         { headers: { 'X-TEST': '1' } }
       )
 
@@ -109,10 +109,9 @@ describe Proxima::Model do
   describe '.find_one' do
 
     it 'sends a query as a get request to the api and returns the first result' do
-      pending
-      mock_response = RestClient::Response.new '[{ "name": "Robert", "account": 1 }]'
-      mock_response.instance_variable_set :@code, 200
-      mock_response.instance_variable_set :@headers, { x_total_count: 5 }
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 200
+      expect(mock_response).to receive(:body).and_return '[{ "name": "Robert", "account": 1 }]'
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:get)
@@ -124,6 +123,7 @@ describe Proxima::Model do
       )
       user = User.find_one(
         { account_id: 1 },
+        {},
         { headers: { 'X-TEST': '1' } }
       )
 
@@ -137,20 +137,20 @@ describe Proxima::Model do
   describe '.count' do
 
     it 'sends a query as a get request to the api and returns the total count' do
-      pending
-      mock_response = RestClient::Response.new '[]'
-      mock_response.instance_variable_set :@code, 200
-      mock_response.instance_variable_set :@headers, { x_total_count: 5 }
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 200
+      expect(mock_response).to receive(:headers).and_return x_total_count: 5
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:get)
           .with("/account/1/user", {
             headers: { :'X-TEST' => '1' },
-            query:   { '$limit' => 0, 'account' => 1 }
+            query:   { '$limit' => 0 }
           })
           .and_return(mock_response)
       )
       user_count = User.count(
+        {},
         { account_id: 1 },
         { headers: { 'X-TEST': '1' } }
       )
@@ -163,7 +163,10 @@ describe Proxima::Model do
   describe '.find_by_id' do
 
     it 'sends a query as a get request to the api and returns the first result' do
-      mock_response = double('response', body: '{ "name": "Robert", "account": 1 }', code: 200)
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 200
+      expect(mock_response).to receive(:body).and_return '{ "name": "Robert", "account": 1 }'
+
       expect_any_instance_of(Proxima::Api).to(
         receive(:get)
           .with("/account/1/user/1", { headers: { :'X-TEST' => '1' } })
@@ -260,11 +263,11 @@ describe Proxima::Model do
   describe '.save' do
 
     it 'sends a post request to the api if the record is new and returns true' do
-      pending
-      mock_response = RestClient::Response.new(
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 201
+      expect(mock_response).to receive(:body).and_return(
         '{ "_id": "1", "name": "Robert", "account": 1 }'
       )
-      mock_response.instance_variable_set :@code, 201
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:post)
@@ -277,11 +280,8 @@ describe Proxima::Model do
     end
 
     it 'sends a put request to the api if the record is new and returns true' do
-      pending
-      mock_response = RestClient::Response.new(
-        '{ "_id": "1", "name": "Robert", "account": 1 }'
-      )
-      mock_response.instance_variable_set :@code, 204
+      mock_response = double('Response')
+      expect(mock_response).to receive(:code).and_return 204
 
       expect_any_instance_of(Proxima::Api).to(
         receive(:put)


### PR DESCRIPTION
This swaps out the net/http library that is part of ruby core for the faster and better implemented https://github.com/httprb/http gem. It's got a solid API, and uses a fork of Node's HTTP parser.