### PR TITLE
[#148869083] Proxima returns nil instead of boolean for TrueClass attributes

### DIFF
--- a/lib/proxima/serialization.rb
+++ b/lib/proxima/serialization.rb
@@ -19,7 +19,7 @@ module Proxima
         end
         value = json_ctx
 
-        next unless value
+        next if value.nil?
 
         if params[:klass]
           begin

--- a/lib/proxima/version.rb
+++ b/lib/proxima/version.rb
@@ -1,5 +1,5 @@
 
 
 module Proxima
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end


### PR DESCRIPTION
We noticed that boolean values such as enable_two_factor_auth were returning `nil` in the proxima response instead of a boolean value. 

This PR fixes the `from_json` serialization method so that we map a value to the field instead of sending `nil` back. 