### PR TITLE
Serialization fix

### DIFF
--- a/lib/proxima/model.rb
+++ b/lib/proxima/model.rb
@@ -159,19 +159,19 @@ module Proxima
       self.restore_attributes
     end
 
-    def destroy
+    def destroy(params = {})
       raise "Cannot destroy a new record" if new_record?
 
-      @response = self.class.api.delete(self.class.delete_by_id_path.call(self.to_h))
+      @response = self.class.api.delete(self.class.delete_by_id_path.call(self.to_h.merge(params)))
 
       return false unless @response.code == 204
       self.persisted = true
     end
 
-    def restore
+    def restore(params = {})
       raise "Cannot restore a new record" if new_record?
 
-      @response = self.class.api.post(self.class.restore_by_id_path.call(self.to_h))
+      @response = self.class.api.post(self.class.restore_by_id_path.call(self.to_h.merge(params)))
 
       return false unless @response.code == 204
       self.persisted = true

--- a/lib/proxima/serialization.rb
+++ b/lib/proxima/serialization.rb
@@ -107,7 +107,7 @@ module Proxima
         json = json.first        if opts[:single_model_from_array] && json.is_a?(Array)
 
         if json.is_a? Array
-          return json.map { |json| self.new.from_json json }
+          return json.map { |json|  self.from_json json }
         end
 
         model            = self.new.from_json json

--- a/lib/proxima/serialization.rb
+++ b/lib/proxima/serialization.rb
@@ -107,7 +107,7 @@ module Proxima
         json = json.first        if opts[:single_model_from_array] && json.is_a?(Array)
 
         if json.is_a? Array
-          return json.map { |json|  self.from_json json }
+          return json.map { |json| self.from_json json }
         end
 
         model            = self.new.from_json json


### PR DESCRIPTION
Ensure models are not falsely flagged as new
`destroy` and `restore` model instance methods now accept params as an argument